### PR TITLE
Windows Render compile - declspec issues

### DIFF
--- a/goon/src/Goon/Application.hpp
+++ b/goon/src/Goon/Application.hpp
@@ -21,7 +21,7 @@ namespace Goon
     /**
      * @brief The application that will be created.
      */
-    class GN_API Application
+    class Application
     {
     public:
         Application();

--- a/goon/src/Goon/Entrypoint.hpp
+++ b/goon/src/Goon/Entrypoint.hpp
@@ -21,14 +21,6 @@ int main(int , char** )
     delete app;
 }
 
-int main(int argc, char *argv[])
-{
-    Goon::Log::Init();
-    auto app = Goon::CreateApplication();
-    app->Run();
-    delete app;
-}
-
 #endif
 
 #ifdef GN_PLATFORM_LINUX

--- a/goon/src/Goon/Log.hpp
+++ b/goon/src/Goon/Log.hpp
@@ -8,7 +8,7 @@ namespace Goon {
     /**
      * @brief Singleton logging class for the engine and application
      */
-    class GN_API Log
+    class Log
     {
         public:
             /**


### PR DESCRIPTION
Windows problem is due to declspecs, and can cause build problems apparantly since we have switched to static lib